### PR TITLE
fix: Make timezone test environment-agnostic using mock

### DIFF
--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -3,6 +3,7 @@ Tests for the messages module.
 """
 
 import unittest
+from unittest.mock import patch
 from datetime import datetime, timezone
 
 from chatd.messages import format_epoch, format_message, compare_roles
@@ -13,18 +14,22 @@ class TestMessages(unittest.TestCase):
     
     def test_format_epoch(self):
         """Test epoch time formatting with timezone conversion."""
-        # Create a specific UTC timestamp (2023-09-15 19:13:00 UTC)
-        # This should convert to 3:13 PM EDT in Eastern time (September is in EDT, so UTC-4)
-        utc_dt = datetime(2023, 9, 15, 19, 13, 0, tzinfo=timezone.utc)
-        timestamp = utc_dt.timestamp()
-        formatted = format_epoch(timestamp)
-        
-        # September 15, 2023 is in EDT (UTC-4), so 19:13 UTC = 15:13 EDT (3:13 PM)
-        # The function should now output without leading zeros and use the correct timezone name
-        
-        # Check that it contains the expected time (without leading zero) and timezone suffix
-        self.assertIn('September, 15 @ 3:13 PM', formatted)
-        self.assertTrue(formatted.endswith('EST') or formatted.endswith('EDT'))
+        # Mock the config to use America/New_York timezone for consistent testing
+        with patch('chatd.config.config') as mock_config:
+            mock_config.timezone = 'America/New_York'
+            
+            # Create a specific UTC timestamp (2023-09-15 19:13:00 UTC)
+            # This should convert to 3:13 PM EDT in Eastern time (September is in EDT, so UTC-4)
+            utc_dt = datetime(2023, 9, 15, 19, 13, 0, tzinfo=timezone.utc)
+            timestamp = utc_dt.timestamp()
+            formatted = format_epoch(timestamp)
+            
+            # September 15, 2023 is in EDT (UTC-4), so 19:13 UTC = 15:13 EDT (3:13 PM)
+            # The function should now output without leading zeros and use the correct timezone name
+            
+            # Check that it contains the expected time (without leading zero) and timezone suffix
+            self.assertIn('September, 15 @ 3:13 PM', formatted)
+            self.assertTrue(formatted.endswith('EST') or formatted.endswith('EDT'))
     
     def test_format_message(self):
         """Test message formatting."""


### PR DESCRIPTION
- Mock the timezone configuration in test_format_epoch to force America/New_York
- Prevents CI failures due to different system timezones (UTC vs local)
- Test now consistently passes in all environments
- All 72 tests passing locally and should pass in CI

The production code correctly detects system timezone, but tests should be deterministic regardless of the environment they run in.