### PR TITLE
Update logging format to include line numbers and remove milliseconds

### DIFF
--- a/chatd/logging_utils.py
+++ b/chatd/logging_utils.py
@@ -64,7 +64,10 @@ def setup_logging(log_level: str = 'INFO', log_file: Optional[str] = None,
         root_logger.removeHandler(handler)
     
     # Create formatter
-    formatter = logging.Formatter('[%(asctime)s] [%(levelname)-7s] %(name)s: %(message)s')
+    formatter = logging.Formatter(
+        '[%(asctime)s %(levelname)s %(name)s:%(lineno)d] %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
     
     # Always add console handler
     console_handler = logging.StreamHandler()


### PR DESCRIPTION
- Changed log format from '[2025-10-03 13:08:28,718] [INFO   ] chatd-internships: message'
  to '[2025-10-03 07:08:28 INFO chatd-internships:236] message'
- Removed milliseconds from timestamp for cleaner output
- Added line number information for better debugging
- Time now displays in local machine timezone