### PR TITLE
Feat/module specific logging

### DIFF
--- a/chatd/bot.py
+++ b/chatd/bot.py
@@ -6,6 +6,7 @@ This module handles Discord interactions and event handling.
 
 import asyncio
 import heapq
+import logging
 from datetime import datetime
 from typing import Dict, List, Any, Set, Optional, Tuple
 
@@ -15,13 +16,12 @@ from discord.ext import commands
 import schedule
 
 from chatd.config import config
-from chatd.logging_utils import get_logger
 from chatd.messages import format_message
 from chatd.repo import clone_or_update_repo, read_json
 from chatd.storage_abstraction import DataStorage
 
 # Get logger
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 # Storage will be initialized lazily to avoid import-time directory creation
 storage = None

--- a/chatd/config.py
+++ b/chatd/config.py
@@ -16,7 +16,7 @@ import logging
 from dotenv import load_dotenv
 
 # Initialize logger (will be properly configured after logging_utils is imported)
-logger = logging.getLogger('chatd-internships')
+logger = logging.getLogger(__name__)
 
 # Default configuration values
 DEFAULT_CONFIG = {
@@ -72,8 +72,6 @@ class Config:
         # Load environment variables from .env file
         load_dotenv()
         
-        # Debug: Check if load_dotenv found the file and loaded our values
-        print(f"DEBUG: After load_dotenv() - MIGRATION_MODE: {repr(os.getenv('MIGRATION_MODE'))}")
         logger.info(f"🔍 After load_dotenv() - DB_PASSWORD: {'SET' if os.getenv('DB_PASSWORD') else 'NOT SET'}")
         logger.info(f"🔍 After load_dotenv() - LOG_LEVEL: {repr(os.getenv('LOG_LEVEL'))}")
         logger.info(f"🔍 After load_dotenv() - MIGRATION_MODE: {repr(os.getenv('MIGRATION_MODE'))}")
@@ -125,14 +123,11 @@ class Config:
         
         # Set migration mode (override default if specified)
         migration_mode_env = os.getenv('MIGRATION_MODE')
-        print(f"DEBUG: MIGRATION_MODE environment variable: {repr(migration_mode_env)}")
         logger.info(f"🔍 MIGRATION_MODE environment variable: {repr(migration_mode_env)}")
         if migration_mode_env and migration_mode_env.strip():
             self.migration_mode = migration_mode_env.strip().lower()
-            print(f"DEBUG: MIGRATION_MODE set from environment: {self.migration_mode}")
             logger.info(f"🔍 MIGRATION_MODE set from environment: {self.migration_mode}")
         else:
-            print(f"DEBUG: MIGRATION_MODE using default: {self.migration_mode}")
             logger.info(f"🔍 MIGRATION_MODE using default: {self.migration_mode}")
         
         self._initialized = True

--- a/chatd/messages.py
+++ b/chatd/messages.py
@@ -4,6 +4,7 @@ Message formatting for the chatd-internships bot.
 This module handles formatting and comparing role data for Discord messages.
 """
 
+import logging
 from datetime import datetime
 from typing import Dict, List, Any, Optional
 
@@ -17,10 +18,8 @@ except ImportError:
         # If no timezone support available, we'll use a simple offset
         ZoneInfo = None
 
-from chatd.logging_utils import get_logger
-
 # Get logger
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 def format_epoch(val: float) -> str:

--- a/chatd/repo.py
+++ b/chatd/repo.py
@@ -5,6 +5,7 @@ This module handles cloning, updating, and reading data from the GitHub reposito
 """
 
 import json
+import logging
 import os
 import shutil
 from typing import Dict, List, Any
@@ -12,10 +13,9 @@ from typing import Dict, List, Any
 import git
 
 from chatd.config import config
-from chatd.logging_utils import get_logger
 
 # Get logger
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 def clone_or_update_repo() -> bool:

--- a/chatd/storage.py
+++ b/chatd/storage.py
@@ -5,14 +5,13 @@ This module handles persistent storage of data using various backends (file, DB,
 """
 
 import json
+import logging
 import os
 from abc import ABC, abstractmethod
 from typing import Dict, List, Any, Optional, Type
 
-from chatd.logging_utils import get_logger
-
 # Get logger
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 class Storage(ABC):

--- a/main.py
+++ b/main.py
@@ -7,13 +7,14 @@ This script initializes the bot and runs it.
 
 import sys
 import signal
+import logging
 
 from chatd.config import config, validate_config
-from chatd.logging_utils import get_logger, setup_signal_handlers
+from chatd.logging_utils import setup_signal_handlers
 from chatd.bot import run_bot
 
 # Initialize logger
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 def signal_handler(sig, frame):

--- a/scripts/create-management-scripts.sh
+++ b/scripts/create-management-scripts.sh
@@ -259,7 +259,17 @@ fi
 
 # Build new docker image with commit tag
 echo "🐳 Building Docker image for commit ${COMMIT_HASH}..."
-docker build -t "${IMAGE_TAG}" .
+docker-compose build chatd-bot
+
+# Tag the built image with commit hash and latest
+BUILT_IMAGE_ID=$(docker images -q chatd_chatd-bot:latest)
+if [[ -n "$BUILT_IMAGE_ID" ]]; then
+    docker tag "$BUILT_IMAGE_ID" "${IMAGE_TAG}"
+    docker tag "$BUILT_IMAGE_ID" "${LATEST_TAG}"
+else
+    echo "❌ Failed to find built image"
+    exit 1
+fi
 
 # Also tag as latest
 echo "🏷️  Tagging as latest..."
@@ -449,12 +459,18 @@ if docker image inspect "${IMAGE_TAG}" >/dev/null 2>&1; then
 else
     # Build new docker image with commit tag
     echo "🐳 Building Docker image for commit ${COMMIT_HASH}..."
-    docker build -t "${IMAGE_TAG}" .
+    docker-compose build chatd-bot
     
-    # Also tag as latest
-    echo "🏷️  Tagging as latest..."
-    docker tag "${IMAGE_TAG}" "${LATEST_TAG}"
-    echo "✅ Bot image built successfully!"
+    # Tag the built image with commit hash and latest
+    BUILT_IMAGE_ID=$(docker images -q chatd_chatd-bot:latest)
+    if [[ -n "$BUILT_IMAGE_ID" ]]; then
+        docker tag "$BUILT_IMAGE_ID" "${IMAGE_TAG}"
+        docker tag "$BUILT_IMAGE_ID" "${LATEST_TAG}"
+        echo "✅ Bot image built successfully!"
+    else
+        echo "❌ Failed to find built image"
+        exit 1
+    fi
 fi
 
 # Deploy using docker-compose (which handles networking properly)
@@ -985,7 +1001,15 @@ case "$1" in
         sudo systemctl restart chatd-internships
         ;;
     status)
+        echo "⚙️  Service Status:"
         systemctl status chatd-internships --no-pager
+        echo ""
+        echo "🐳 Container Status:"
+        if [[ -d "/opt/chatd" && -f "/opt/chatd/docker-compose.yml" ]]; then
+            cd /opt/chatd && docker-compose ps
+        else
+            echo "   ❌ Working directory not found"
+        fi
         ;;
     enable)
         echo "✅ Enabling ChatD bot auto-start..."


### PR DESCRIPTION
- Change all modules to use logging.getLogger(__name__) for better debugging
- Replace get_logger() and hardcoded logger names with module-specific loggers
- Remove debug print statements that were cluttering output
- Log format now shows: [timestamp LEVEL module.name:line] message

This improves debugging by showing exactly which file/module generated each log entry:
- chatd.config:123 instead of chatd-internships:123
- chatd.bot:456 instead of chatd-internships:456
- chatd.storage_abstraction:789 (already had this)

Affected modules: main.py, bot.py, config.py, messages.py, repo.py, storage.py