### PR TITLE
Add dynamic timezone support to Docker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,10 +43,15 @@ services:
       - DB_NAME=chatd
       - DB_USER=chatd
       - DB_TYPE=postgresql
+      # Timezone configuration - uses host machine timezone
+      - TZ=${TZ:-UTC}
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
       - ./Summer2026-Internships:/app/Summer2026-Internships
+      # Mount timezone data for proper local time
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     depends_on:
       chatd-postgres:
         condition: service_healthy


### PR DESCRIPTION
- Use TZ=${TZ:-UTC} to inherit host machine timezone
- Mount host timezone files for proper local time display
- This allows the bot to show log timestamps in local time instead of UTC
- Works with any timezone the host machine is set to